### PR TITLE
Refactor Legal Content Display with LegalContentDialog Component

### DIFF
--- a/src/app/activities/[activityId]/edit/sections/ActivitiyInfoSection.js
+++ b/src/app/activities/[activityId]/edit/sections/ActivitiyInfoSection.js
@@ -1,6 +1,5 @@
 "use client";
 
-import { StyledMuiLink } from "@/app/(homepage)/components/Link";
 import {
   createDiscount,
   getActivity,
@@ -15,7 +14,6 @@ import HighlightOffRoundedIcon from "@mui/icons-material/HighlightOffRounded";
 import {
   Button,
   Chip,
-  Dialog,
   FormControl,
   IconButton,
   InputAdornment,
@@ -56,7 +54,7 @@ import {
 } from "../components/formikFields";
 import { SmFlex } from "../components/responsiveFlexes";
 import { isTimeStringAfter, isTimeStringBefore, numericSchema, timeschema } from "../utils";
-import { TermsAndConditionsContainer } from "./TermsAndConditionsSection";
+import LegalContentDialog from "@/components/LegalTemplates/LegalContentDialog";
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);
 
@@ -75,21 +73,6 @@ function SlideHeader({ label, close }) {
   );
 }
 
-function TermsAndConditionsView({ activity, handleClose }) {
-  return (
-    <TermsAndConditionsContainer>
-      {activity?.termsAndConditions ? (
-        <Box dangerouslySetInnerHTML={{ __html: activity?.termsAndConditions }} />
-      ) : (
-        <Typography sx={{ fontWeight: 700 }}>You must add legal disclsimers here.</Typography>
-      )}
-
-      <Button variant="contained" color="green" fullWidth onClick={handleClose} sx={{ mt: 2 }}>
-        Close
-      </Button>
-    </TermsAndConditionsContainer>
-  );
-}
 
 export function ActivityDetails({ sx, editMode=false }) {
   const { activityId, targetDate } = useParams();
@@ -102,7 +85,10 @@ export function ActivityDetails({ sx, editMode=false }) {
   const endingDiscount = discounts?.find((discount) => discount.type === "ending"); 
 
   const formatDateString = (dateString) => dateString && dayjs(dateString).format("DD MMMM");
-  const [termsCoditionsOpen, setTermsCoditionsOpen] = React.useState(false);
+  const privacyPolicyHtml = `
+  <h1>Privacy Policy</h1>
+  <p>Your privacy policy content goes here.</p>
+`;
 
   return (
     <Box
@@ -219,23 +205,8 @@ export function ActivityDetails({ sx, editMode=false }) {
         </>
       )}
       <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "start" }}>
-        <StyledMuiLink
-          onClick={() => {
-            console.log(1);
-            setTermsCoditionsOpen(true);
-          }}
-        >
-          Terms & conditions
-        </StyledMuiLink>
+        <LegalContentDialog linkText="Privacy policy" htmlContent={privacyPolicyHtml} />;
         <ActivityDiscountedPrice activity={activity} />
-
-        <Dialog
-          onClose={() => setTermsCoditionsOpen(false)}
-          open={termsCoditionsOpen}
-          PaperProps={{ sx: { maxWidth: "none" } }}
-        >
-          <TermsAndConditionsView activity={activity} handleClose={() => setTermsCoditionsOpen(false)} />
-        </Dialog>
       </Box>
     </Box>
   );

--- a/src/components/LegalTemplates/LegalContentDialog.js
+++ b/src/components/LegalTemplates/LegalContentDialog.js
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { Box, Button, Dialog, Typography } from '@mui/material';
+import { TermsAndConditionsContainer } from '@/app/activities/[activityId]/edit/sections/TermsAndConditionsSection';
+import { StyledMuiLink } from "@/app/(homepage)/components/Link";
+
+function LegalContentDialog({ linkText, htmlContent }) {
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "start" }}>
+      <StyledMuiLink onClick={handleOpen} sx={{ cursor: "pointer" }}>
+        {linkText}
+      </StyledMuiLink>
+      <Dialog onClose={handleClose} open={open} PaperProps={{ sx: { maxWidth: "none" } }}>
+        <TermsAndConditionsContainer>
+          {htmlContent ? (
+            <Box dangerouslySetInnerHTML={{ __html: htmlContent }} />
+          ) : (
+            <Typography sx={{ fontWeight: 700 }}>No content available.</Typography>
+          )}
+          <Button variant="contained" color="primary" fullWidth onClick={handleClose} sx={{ mt: 2 }}>
+            Close
+          </Button>
+        </TermsAndConditionsContainer>
+      </Dialog>
+    </Box>
+  );
+}
+
+export default LegalContentDialog;


### PR DESCRIPTION
I have added an example of using the LegalContentDialog
![image](https://github.com/digital-brother/ooscca-fe/assets/45142827/1662e0a0-e119-4bd8-8306-e4ee50319348)

![image](https://github.com/digital-brother/ooscca-fe/assets/45142827/6b2886f6-273f-4f38-a150-14060b014404)

The same will be if you need to do the same for the Terms and Conditions.
